### PR TITLE
RenameSuggestion

### DIFF
--- a/org.knime.workbench.explorer.view/src/org/knime/workbench/explorer/view/actions/CopyMove.java
+++ b/org.knime.workbench.explorer.view/src/org/knime/workbench/explorer/view/actions/CopyMove.java
@@ -325,7 +325,7 @@ public final class CopyMove {
             return;
         }
         // do not delete workflowgroups that have workflows or other files as children...
-        if (hasOnlyWorkflowGroupChidlren(fileStore, monitor)) {
+        if (hasOnlyWorkflowGroupChildren(fileStore, monitor)) {
             fileStore.delete(EFS.NONE, monitor);
         } else {
             // ... but delete contained workflow groups that are empty
@@ -336,14 +336,14 @@ public final class CopyMove {
 
     }
 
-    private boolean hasOnlyWorkflowGroupChidlren(final AbstractExplorerFileStore fileStore,
-        final IProgressMonitor monitor) throws CoreException {
+    private boolean hasOnlyWorkflowGroupChildren(final AbstractExplorerFileStore fileStore,
+                                                 final IProgressMonitor monitor) throws CoreException {
         if (AbstractExplorerFileStore.isWorkflowGroup(fileStore)) {
             for (AbstractExplorerFileStore childStore : fileStore.childStores(EFS.NONE, monitor)) {
                 if (!AbstractExplorerFileStore.isWorkflowGroup(childStore)) {
                     return false;
                 }
-                if (!hasOnlyWorkflowGroupChidlren(childStore, monitor)) {
+                if (!hasOnlyWorkflowGroupChildren(childStore, monitor)) {
                     return false;
                 }
             }

--- a/org.knime.workbench.workflowcoach/src/org/knime/workbench/workflowcoach/prefs/WorkflowCoachPreferencePage.java
+++ b/org.knime.workbench.workflowcoach/src/org/knime/workbench/workflowcoach/prefs/WorkflowCoachPreferencePage.java
@@ -174,7 +174,7 @@ public class WorkflowCoachPreferencePage extends PreferencePage implements IWork
         m_updateButton.addSelectionListener(new SelectionAdapter() {
             @Override
             public void widgetSelected(final SelectionEvent e) {
-                onUpate();
+                onUpdate();
             }
         });
         m_lastUpdate = new Label(manualUpdateComp, SWT.NONE);
@@ -199,7 +199,7 @@ public class WorkflowCoachPreferencePage extends PreferencePage implements IWork
     /**
      * Called when the update button has been pressed.
      */
-    private void onUpate() {
+    private void onUpdate() {
         Display.getDefault().syncExec(() -> {
             m_updateButton.setEnabled(false);
             m_lastUpdate.setText("Updating ...");


### PR DESCRIPTION
### Renaming Suggestion of Method Names to Make Them More Descriptive
---
**Description**
---

We have developed a tool (**NameSpotter**) for identifying non-descriptive method names, and using this tool we find two non-descriptive method names in your repository:
```java
/* Non-descriptive Method Name in org.knime.workbench.workflowcoach/src/org/knime/workbench/workflowcoach/prefs/WorkflowCoachPreferencePage.java */
    private void onUpate() {
        Display.getDefault().syncExec(() -> {
            m_updateButton.setEnabled(false);
            m_lastUpdate.setText("Updating ...");
            m_lastUpdate.setForeground(Display.getCurrent().getSystemColor(SWT.COLOR_BLACK));
            setValid(false);
        });
```
```java
/* Non-descriptive Method Name in org.knime.workbench.explorer.view/src/org/knime/workbench/explorer/view/actions/CopyMove.java */
    private boolean hasOnlyWorkflowGroupChidlren(final AbstractExplorerFileStore fileStore,
                                                 final IProgressMonitor monitor) throws CoreException {
        if (AbstractExplorerFileStore.isWorkflowGroup(fileStore)) {
            for (AbstractExplorerFileStore childStore : fileStore.childStores(EFS.NONE, monitor)) {
                if (!AbstractExplorerFileStore.isWorkflowGroup(childStore)) {
                    return false;
                }
                if (!hasOnlyWorkflowGroupChildren(childStore, monitor)) {
                    return false;
                }
            }
        }
        return true;
    }

```

We considered these two names as non-descriptive because they both contain typos (onUpate -> onUpdate, and hasOnlyWorkflowGroupChidlren -> hasOnlyWorkflowGroupChildren). We have made the corresponding changes and submitted a pull request.

Do you agree with the judgment? 

- If not, could you please leave your valuable opinion?

- If you do agree, the relevant modification has been submitted as a PR, and thanks for your precious time to consider it.